### PR TITLE
Added a naive fix to github workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,6 @@
 name: Build
 
-on:
-  push:
+on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always
@@ -31,27 +30,33 @@ jobs:
         run: cargo fmt --all --check
 
       - name: Clippy X11
-        run: cargo clippy --all --all-targets --features all
+        run: cargo clippy --all --all-targets --features all-bins
 
       - name: Clippy wayland
-        run: cargo clippy --all --all-targets --features 'all wayland'
+        run: cargo clippy --all --all-targets --features all-bins,wayland
 
       - name: Test X11
-        run: cargo test --all --features all 
+        run: cargo test --all --features all-bins
 
       - name: Test wayland
-        run: cargo test --all --features 'all wayland'
+        run: cargo test --all --features all-bins,wayland
 
       - name: Build X11
-        run: cargo build --features all --release
+        run: cargo build --features all-bins --release
 
-      - name: Build wayland
-        run: cargo build --features 'all wayland' --release
-
-      - name: Upload
+      - name: Upload X11 daemon
         uses: actions/upload-artifact@v3
         with:
-          name: clipcatd
+          name: clipcatd-x11
+          path: target/release/clipcatd
+
+      - name: Build wayland
+        run: cargo build --features all-bins,wayland --release
+
+      - name: Upload wayland daemon
+        uses: actions/upload-artifact@v3
+        with:
+          name: clipcatd-wayland
           path: target/release/clipcatd
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,14 +30,23 @@ jobs:
       - name: Format
         run: cargo fmt --all --check
 
-      - name: Clippy
-        run: cargo clippy --all --all-features --all-targets
+      - name: Clippy X11
+        run: cargo clippy --all --all-targets --features all
 
-      - name: Test
-        run: cargo test --all --all-features
+      - name: Clippy wayland
+        run: cargo clippy --all --all-targets --features 'all wayland'
 
-      - name: Build
-        run: cargo build --all-features --release
+      - name: Test X11
+        run: cargo test --all --features all 
+
+      - name: Test wayland
+        run: cargo test --all --features 'all wayland'
+
+      - name: Build X11
+        run: cargo build --features all --release
+
+      - name: Build wayland
+        run: cargo build --features 'all wayland' --release
 
       - name: Upload
         uses: actions/upload-artifact@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,28 +4,6 @@ version = "0.5.0"
 authors = ["xrelkd 46590321+xrelkd@users.noreply.github.com"]
 edition = "2018"
 
-[features]
-all = ["clipcatd", "clipcatctl", "clipcat-menu", "clipcat-notify"]
-default = ["clipcatd", "clipcatctl", "clipcat-menu"]
-
-app = ["app_dirs", "structopt", "toml", "tracing-subscriber", "tracing-futures"]
-monitor = ["x11-clipboard"]
-daemon = [
-  "daemonize", "libc",
-  "tracing-subscriber", "tracing-journald",
-  "tokio/signal", "serde_json",
-  "bincode"
-]
-external_editor = ["tokio/process"]
-builtin_finder = ["skim"]
-
-wayland = ["wl-clipboard-rs"]
-
-clipcatd = ["app", "monitor", "daemon"]
-clipcatctl = ["app", "tokio/process", "tokio/io-std", "tokio/fs", "external_editor"]
-clipcat-menu = ["app", "tokio/process", "external_editor", "builtin_finder"]
-clipcat-notify = ["structopt", "monitor"]
-
 [lib]
 name = "clipcat"
 path = "src/lib.rs"
@@ -83,12 +61,31 @@ daemonize = { version = "0.4", optional = true }
 
 skim = { version = "0.10", optional = true }
 
+[features]
+all-bins = ["clipcatd", "clipcatctl", "clipcat-menu", "clipcat-notify"]
+default = ["clipcatd", "clipcatctl", "clipcat-menu"]
+
+app = ["app_dirs", "structopt", "toml", "tracing-subscriber", "tracing-futures"]
+monitor = ["x11-clipboard"]
+daemon = [
+  "daemonize", "libc",
+  "tracing-subscriber", "tracing-journald",
+  "tokio/signal", "serde_json",
+  "bincode"
+]
+external_editor = ["tokio/process"]
+builtin_finder = ["skim"]
+
+wayland = ["wl-clipboard-rs"]
+
+clipcatd = ["app", "monitor", "daemon"]
+clipcatctl = ["app", "tokio/process", "tokio/io-std", "tokio/fs", "external_editor"]
+clipcat-menu = ["app", "tokio/process", "external_editor", "builtin_finder"]
+clipcat-notify = ["structopt", "monitor"]
+
 [build-dependencies]
 tonic-build = { version = "0.4", features = ["prost"] }
 
 [profile.release]
 opt-level = 3
 lto = true
-
-[profile.dev]
-opt-level = 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /build
 
 ADD . /build
 
-RUN cargo build --release --features=all
+RUN cargo build --release --features=all-bins
 
 FROM debian:stable-slim
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -7,14 +7,24 @@ command = "cargo"
 args = ["build"]
 dependencies = ["format"]
 
-[tasks.build-all]
+[tasks.build-all-x11]
 command = "cargo"
-args = ["build", "--features=all"]
+args = ["build", "--features=all-bins"]
 dependencies = ["format"]
 
-[tasks.build-release]
+[tasks.build-all-wayland]
 command = "cargo"
-args = ["build", "--release", "--features=all"]
+args = ["build", "--features=all-bins,wayland"]
+dependencies = ["format"]
+
+[tasks.build-release-x11]
+command = "cargo"
+args = ["build", "--release", "--features=all-bins"]
+dependencies = ["format"]
+
+[tasks.build-release-wayland]
+command = "cargo"
+args = ["build", "--release", "--features=all-bins,wayland"]
 dependencies = ["format"]
 
 [tasks.test]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ cargo install --path . --features clipcatd,clipcat-menu,clipcatctl,clipcat-not
 ```
 or with wayland support:
 ```shell
-$ cargo install --path . --features all
+$ cargo install --path . --features all-bins
 ```
 
 ## Architecture


### PR DESCRIPTION
I add a naive fix to github workflow. Now the workflow should be able to test both X11 and wayland version of clipcat.

Maybe update-artifact should also be changed latter, it's up to your decision. 