### PR TITLE
Fix crash in a better way

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,8 +2322,7 @@ dependencies = [
 [[package]]
 name = "x11-clipboard"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0827f86aa910c4e73329a4f619deabe88ebb4b042370bf023c2d5d8b4eb54695"
+source = "git+https://github.com/wrvsrx/x11-clipboard?rev=357e7c7fbb2fc9fd6a8b46ed6ce191f8182a594d#357e7c7fbb2fc9fd6a8b46ed6ce191f8182a594d"
 dependencies = [
  "x11rb",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,6 +698,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,6 +2230,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-wsapoll"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2302,20 +2321,33 @@ dependencies = [
 
 [[package]]
 name = "x11-clipboard"
-version = "0.6.0"
-source = "git+https://github.com/xrelkd/x11-clipboard?tag=v0.6.0#de648ede312e6b236e3b92119a014cac064b9e38"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0827f86aa910c4e73329a4f619deabe88ebb4b042370bf023c2d5d8b4eb54695"
 dependencies = [
- "xcb",
+ "x11rb",
 ]
 
 [[package]]
-name = "xcb"
-version = "0.9.0"
+name = "x11rb"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62056f63138b39116f82a540c983cc11f1c90cd70b3d492a70c25eaa50bd22a6"
+checksum = "592b4883219f345e712b3209c62654ebda0bb50887f330cbd018d0f654bfd507"
 dependencies = [
- "libc",
- "log",
+ "gethostname",
+ "nix 0.24.3",
+ "winapi",
+ "winapi-wsapoll",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56b245751c0ac9db0e006dc812031482784e434630205a93c73cfefcaabeac67"
+dependencies = [
+ "nix 0.24.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ toml = { version = "0.5", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", optional = true }
 
-x11-clipboard = { git = "https://github.com/xrelkd/x11-clipboard", tag = "v0.6.0", optional = true }
+x11-clipboard = { version = "0.7.0", optional = true }
 wl-clipboard-rs = { version = "0.7", optional = true }
 
 bincode = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ toml = { version = "0.5", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", optional = true }
 
-x11-clipboard = { version = "0.7.0", optional = true }
+x11-clipboard = { git = "https://github.com/wrvsrx/x11-clipboard", rev = "357e7c7fbb2fc9fd6a8b46ed6ce191f8182a594d", optional = true }
 wl-clipboard-rs = { version = "0.7", optional = true }
 
 bincode = { version = "1", optional = true }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -212,43 +212,24 @@ impl ClipboardWaitProvider {
         })
     }
 
-    fn atoms(&self) -> (u32, u32, u32, u32) {
+    fn atoms(&self) -> (u32, u32, u32) {
         let atom_clipboard = match self.clipboard_type {
             ClipboardType::Clipboard => self.clipboard.getter.atoms.clipboard,
             ClipboardType::Primary => self.clipboard.getter.atoms.primary,
         };
         let atom_utf8string = self.clipboard.getter.atoms.utf8_string;
-        let atom_string = self.clipboard.getter.atoms.string;
         let atom_property = self.clipboard.getter.atoms.property;
-        (atom_clipboard, atom_utf8string, atom_string, atom_property)
+        (atom_clipboard, atom_utf8string, atom_property)
     }
 
     pub(crate) fn load(&self) -> Result<Vec<u8>, x11_clipboard::error::Error> {
-        let (c, utf8, string, prop) = self.atoms();
-
-        let result = self.clipboard.load(c, utf8, prop, None);
-
-        result.or_else(|err| {
-            if matches!(err, x11_clipboard::error::Error::UnexpectedType(_target)) {
-                self.clipboard.load(c, string, prop, None)
-            } else {
-                Err(err)
-            }
-        })
+        let (c, utf8, prop) = self.atoms();
+        self.clipboard.load(c, utf8, prop, None)
     }
 
     pub(crate) fn load_wait(&self) -> Result<Vec<u8>, x11_clipboard::error::Error> {
-        let (c, utf8, string, prop) = self.atoms();
-
-        let result = self.clipboard.load_wait(c, utf8, prop);
-
-        result.or_else(|err| {
-            if matches!(err, x11_clipboard::error::Error::UnexpectedType(_target)) {
-                self.clipboard.load_wait(c, string, prop)
-            } else {
-                Err(err)
-            }
-        })
+        let (c, utf8, prop) = self.atoms();
+        self.clipboard.load_wait(c, utf8, prop)
     }
 }
 #[cfg(feature = "wayland")]


### PR DESCRIPTION
Upstream problem has been fixed in my folk, therefore rebundant error
handling #4 is no longer needed. In fact, previous error handling (https://github.com/Icelk/clipcat/pull/4)
doesn't make much sense, although it works. After upstream fix it works
in a reasonable way.