### PR TITLE
Update nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,2 @@
-nix_direnv_watch_file flake.nix flake.lock
+nix_direnv_watch_file flake.nix flake.lock shell.nix default.nix
 use flake .

--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,12 @@ rustPlatform.buildRustPackage {
 
   src = ./.;
 
-  cargoSha256 = "sha256-ZHZeM69iFOTPpqhOGENxrXNnO921s2E5Shcazobgizs=";
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+    outputHashes = {
+      "x11-clipboard-0.7.0" = "sha256-E/3R94DB3gHhK2mnEc1UF/i0FvbRHi4uDFmRZsAtXS0=";
+    };
+  };
 
   # needed for internal protobuf c wrapper library
   PROTOC = "${protobuf}/bin/protoc";

--- a/default.nix
+++ b/default.nix
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage {
   ];
   buildInputs = [ xorg.libxcb ];
 
-  # buildFeatures = [ "all" ];
+  buildFeatures = [ "all-bins" ];
 
   postInstall = ''
     installShellCompletion --bash completions/bash-completion/completions/*

--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage {
 
   src = ./.;
 
-  cargoSha256 = "sha256-s80CGlIXcChyX5CEjIV8W7n//LmOSJA8SdC3CoZN2vg=";
+  cargoSha256 = "sha256-ZHZeM69iFOTPpqhOGENxrXNnO921s2E5Shcazobgizs=";
 
   # needed for internal protobuf c wrapper library
   PROTOC = "${protobuf}/bin/protoc";

--- a/flake.nix
+++ b/flake.nix
@@ -12,13 +12,13 @@
         pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
         inherit (pkgs) callPackage;
       in
-      rec {
+      {
         packages = rec {
           clipcat = callPackage ./default.nix { };
           default = clipcat;
         };
         devShells = rec {
-          clipcat = callPackage ./shell.nix { inherit (packages) clipcat; };
+          clipcat = callPackage ./shell.nix { };
           default = clipcat;
         };
         formatter = pkgs.nixpkgs-fmt;

--- a/flake.nix
+++ b/flake.nix
@@ -8,16 +8,20 @@
 
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
-      in rec {
+      let
+        pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
+        inherit (pkgs) callPackage;
+      in
+      rec {
         packages = rec {
-          clipcat = pkgs.callPackage ./default.nix { };
+          clipcat = callPackage ./default.nix { };
           default = clipcat;
         };
         devShells = rec {
-          clipcat = import ./shell.nix { inherit (packages) clipcat; inherit (pkgs) mkShell; };
+          clipcat = callPackage ./shell.nix { inherit (packages) clipcat; };
           default = clipcat;
         };
+        formatter = pkgs.nixpkgs-fmt;
       }
     );
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,10 @@
-{ mkShell, clipcat }:
+{ mkShell, clipcat, clippy }:
 
 mkShell {
   inputsFrom = [ clipcat ];
+  buildInputs = [
+    clippy
+  ];
   # needed for internal protobuf c wrapper library
   inherit (clipcat)
     PROTOC

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,8 @@
-{ mkShell, clipcat, clippy }:
-
+{ pkgs ? (import <nixpkgs> {}) }:
+let
+  inherit (pkgs) callPackage mkShell clippy cargo;
+  clipcat = callPackage ./default.nix { };
+in
 mkShell {
   inputsFrom = [ clipcat ];
   buildInputs = [


### PR DESCRIPTION
1. `nix-shell` should work now.
2. replace `cargoSha256` by `cargoLock`. Before this change, `cargoSha256` should be updated manually everytime contents of this repo change, otherwise `nix build .` will fail. Now it uses information in cargo.lock and manually computing hash is no longer needed (unless update my folk of x11-clipboard, it's a git repo therefore cargo doesn't store its hash in Cargo.lock).