### PR TITLE
Fix chrome paste taking a long time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 
 # nix build result
 result
+
+# direnv cache
+.direnv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "x11-clipboard"
 version = "0.7.0"
-source = "git+https://github.com/wrvsrx/x11-clipboard?rev=357e7c7fbb2fc9fd6a8b46ed6ce191f8182a594d#357e7c7fbb2fc9fd6a8b46ed6ce191f8182a594d"
+source = "git+https://github.com/wrvsrx/x11-clipboard?rev=d7eb4d7de3b6560ae461ad55562517fed3ca0f04#d7eb4d7de3b6560ae461ad55562517fed3ca0f04"
 dependencies = [
  "x11rb",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ toml = { version = "0.5", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", optional = true }
 
-x11-clipboard = { git = "https://github.com/wrvsrx/x11-clipboard", rev = "357e7c7fbb2fc9fd6a8b46ed6ce191f8182a594d", optional = true }
+x11-clipboard = { git = "https://github.com/wrvsrx/x11-clipboard", rev = "d7eb4d7de3b6560ae461ad55562517fed3ca0f04", optional = true }
 wl-clipboard-rs = { version = "0.7", optional = true }
 
 bincode = { version = "1", optional = true }

--- a/default.nix
+++ b/default.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage {
   cargoLock = {
     lockFile = ./Cargo.lock;
     outputHashes = {
-      "x11-clipboard-0.7.0" = "sha256-E/3R94DB3gHhK2mnEc1UF/i0FvbRHi4uDFmRZsAtXS0=";
+      "x11-clipboard-0.7.0" = "sha256-ToDy7vWPRYk8mrmL+77HJypE91b6z/NaDTUDgRe20d0=";
     };
   };
 


### PR DESCRIPTION
This bug causes clipcat take a long time to paste into chrome, I fix it
in https://github.com/quininer/x11-clipboard/compare/357e7c7fbb2fc9fd6a8b46ed6ce191f8182a594d..8f2459170e4223332e7e46ca57b4dcf208a41b88.

For detail information, check commit message in these two commits.